### PR TITLE
[OxygenMeter] - make it 2 minutes and instantiate 10 of health items

### DIFF
--- a/NoMansLand/Assets/Scripts/OxygenMeter.cs
+++ b/NoMansLand/Assets/Scripts/OxygenMeter.cs
@@ -13,9 +13,9 @@ public class OxygenMeter : MonoBehaviour
     public GameObject goscreen; 
     private bool isPlaying;
 
-    public float maxTime = 400f;
+    public float maxTime = 200f;
 
-    public float time = 400f;
+    public float time = 200f;
 
     private void Start()
     {

--- a/NoMansLand/Assets/Scripts/RandomSpawner.cs
+++ b/NoMansLand/Assets/Scripts/RandomSpawner.cs
@@ -8,7 +8,7 @@ public class RandomSpawner : MonoBehaviour
 {
     public GameObject CollectiblePrefab;
     public GameObject HealthItem; // the health regenerate item 
-    public int HEALTH_ITEM_COUNT = 5; // number of health regenerate items spawned 
+    public int HEALTH_ITEM_COUNT = 10; // number of health regenerate items spawned 
     public Terrain terrain;
     private List<GameObject> spaceShipParts = new List<GameObject>(); // A list of all the individual parts of the ship
     public int terrainXPos; // corner X position of the terrain 


### PR DESCRIPTION
Oxygen meter should be 2 minutes and 10 health items should spawn instead of 5