### PR TITLE
Player sprint functionality on L1 button HOLD

### DIFF
--- a/NoMansLand/Assets/Scripts/Player/CharacterControllerMovement.cs
+++ b/NoMansLand/Assets/Scripts/Player/CharacterControllerMovement.cs
@@ -14,13 +14,13 @@ public class CharacterControllerMovement : MonoBehaviour
 
     // Move
     private Vector3 move;
-    private float speed = 80f;
+    private float speed = 70f;
     private float turnSmoothTime = 0.1f;
     private float turnSmoothVelocity;
     
     // Speed constants
     private float sprintSpeed = 110f;
-    private float normalSpeed = 80f;
+    private float normalSpeed = 70f;
     public bool decreaseHealth;
     
     // Jump
@@ -60,7 +60,8 @@ public class CharacterControllerMovement : MonoBehaviour
         controls.Gameplay.Move.canceled += ctx => move = Vector3.zero;
         
         controls.Gameplay.Jump.performed += ctx => Jump();
-        controls.Gameplay.Sprint.performed += ctx => Sprint();
+        controls.Gameplay.Sprint.performed += ctx => Sprint(true);
+        controls.Gameplay.Sprint.canceled += ctx => Sprint(false);
         
         collectibleHoldSlot = GameObject.Find("CollectibleHolder");
         controls.Gameplay.HandleObject.performed += ctx => HandleObject();
@@ -75,9 +76,9 @@ public class CharacterControllerMovement : MonoBehaviour
         }
     }
     
-    void Sprint()
+    void Sprint(bool isSprint)
     {
-        if (speed < sprintSpeed)
+        if (isSprint)
         {
             speed = sprintSpeed;
             jumpScale = 0.1f;

--- a/NoMansLand/Assets/Scripts/Player/PlayerControls.cs
+++ b/NoMansLand/Assets/Scripts/Player/PlayerControls.cs
@@ -107,7 +107,7 @@ public class @PlayerControls : IInputActionCollection, IDisposable
                 {
                     ""name"": """",
                     ""id"": ""5283ed73-23a8-40b4-9fe6-9123aa51c213"",
-                    ""path"": ""<Gamepad>/buttonEast"",
+                    ""path"": ""<Gamepad>/leftShoulder"",
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",

--- a/NoMansLand/Assets/Scripts/Player/PlayerControls.inputactions
+++ b/NoMansLand/Assets/Scripts/Player/PlayerControls.inputactions
@@ -94,7 +94,7 @@
                 {
                     "name": "",
                     "id": "5283ed73-23a8-40b4-9fe6-9123aa51c213",
-                    "path": "<Gamepad>/buttonEast",
+                    "path": "<Gamepad>/leftShoulder",
                     "interactions": "",
                     "processors": "",
                     "groups": "",


### PR DESCRIPTION
No set up required

- Use and hold L1 to sprint (changed from O because player also needs to press X for jumping and it's harder to hold O and press X at the same time)